### PR TITLE
SLDEV-7680

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <artifacts.folder>${resources.folder}/artifacts</artifacts.folder>
         <testng.version>6.1.1</testng.version>
         <mockito.version>1.10.19</mockito.version>
-        <java.agent.infra.version>[2.0.0-SNAPSHOT],[2.0,)</java.agent.infra.version>
+        <java.agent.infra.version>[3.0.0-SNAPSHOT],[3.0,)</java.agent.infra.version>
     </properties>
 
 
@@ -140,6 +140,36 @@
                         </manifestEntries>
                     </archive>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>display-info</id>
+                        <configuration>
+                            <rules>
+                                <enforceBytecodeVersion>
+                                    <maxJdkVersion>1.${java.level}</maxJdkVersion>
+                                    <excludes>
+                                        <!-- These are original excludes, as in the parent pom. -->
+                                        <exclude>org.jenkins-ci.main:jenkins-core</exclude>
+                                        <exclude>org.jenkins-ci.main:cli</exclude>
+                                        <exclude>org.jenkins-ci.main:jenkins-test-harness</exclude>
+                                        <exclude>com.google.code.findbugs:annotations</exclude>
+
+                                        <!-- Excluding these, as jackson's Java bytecode version is 1.6, documentation
+                                        states support for 1.7, but the enforcer fails due to presence of a Java 9
+                                        module class in the jackson JAR. -->
+                                        <exclude>com.fasterxml.jackson.core:jackson-core:jar:2.11.1</exclude>
+                                        <exclude>com.fasterxml.jackson.core:jackson-annotations:jar:2.11.1</exclude>
+                                        <exclude>com.fasterxml.jackson.core:jackson-databind:jar:2.11.1</exclude>
+                                    </excludes>
+                                </enforceBytecodeVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/io/sealights/plugins/sealightsjenkins/integration/JenkinsPomFile.java
+++ b/src/main/java/io/sealights/plugins/sealightsjenkins/integration/JenkinsPomFile.java
@@ -11,7 +11,6 @@ import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.ByteArrayOutputStream;
@@ -51,7 +50,7 @@ public class JenkinsPomFile extends PomFile {
     }
 
     @Override
-    public void backup() throws Exception {
+    public void backup(String workspacePath) throws Exception {
         String backupFile = this.filename + BACKUP_EXTENSION;
         LOGGER.info("JenkinsPomFile - creating a back up file: " + backupFile);
         VirtualChannel channel = Computer.currentComputer().getChannel();


### PR DESCRIPTION
- Adjusted to changes in pom integration: collecting pom files now results in `CollectedPomFiles` not in `List<PomFile>`, `backup` method now takes a workspace path as an argument (though the path is used only in a case unrelated to jenkins-plugin).

- Bumped up used infra major version to 3.

- Added exception to enforcer rule for bytecode version for jackson library. Jackson is compatible with java 1.7, but it's build with a plugin that also puts in its JAR a file used for Java 9 modules. The file's presence causes enforcer to fail the build.